### PR TITLE
Fix bug with detecting format of URLs with query strings

### DIFF
--- a/tabulator/helpers.py
+++ b/tabulator/helpers.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import os
 import ast
 from chardet.universaldetector import UniversalDetector
 from six.moves.urllib.parse import urlparse
@@ -37,7 +36,13 @@ def detect_format(source):
     if hasattr(source, 'read'):
         format = ''
     else:
-        format = os.path.splitext(source)[1].replace('.', '')
+        parsed_source = urlparse(source)
+        path = parsed_source.path
+        if not path:
+            # FIXME: This supports valid paths like file://foo.csv, but also
+            # invalid ones like http://foo.csv
+            path = parsed_source.netloc
+        format = path.split('.')[-1].lower()
     return format
 
 

--- a/tests/module/test_helpers.py
+++ b/tests/module/test_helpers.py
@@ -24,7 +24,11 @@ class Test_detect_format(unittest.TestCase):
     # Tests
 
     def test(self):
-        self.assertEqual(module.detect_format('path.csv'), 'csv')
+        self.assertEqual(module.detect_format('path.CsV'), 'csv')
+
+    def test_works_with_urls_with_query_and_fragment_components(self):
+        url = 'http://someplace.com/foo/path.csv?foo=bar#baz'
+        self.assertEqual(module.detect_format(url), 'csv')
 
 
 class Test_detect_encoding(unittest.TestCase):

--- a/tests/module/test_topen.py
+++ b/tests/module/test_topen.py
@@ -26,6 +26,8 @@ class Test_topen(unittest.TestCase):
     # Tests
 
     def test_supported_in_source(self):
+        # FIXME: This is testing if paths like "http://path.csv" work, which
+        # aren't valid.
         for scheme in ['file', 'text', 'ftp', 'ftps', 'http', 'https']:
             for format in ['csv', 'xls', 'xlsx', 'json']:
                 patch.object(module, '_LOADERS', {scheme: self.Loader}).start()


### PR DESCRIPTION
This is a tiny improvement, but as I've done it on datapackages (https://github.com/datapackages/datapackage-py/commit/6fba4315f5fc1cdb30d6000b9d081946fbb1434a), I've went ahead and done it here as well.

The tests are failing on Travis because it can't find the `LICENSE.md`. That's unrelated to these changes.